### PR TITLE
Fix RTMP port display condition

### DIFF
--- a/src/tools
+++ b/src/tools
@@ -75,10 +75,10 @@ if (posix_getpwuid(posix_geteuid())['name'] == 'root') {
 				echo 'SSL Ports: ' . implode(', ', $rConfig['https']) . "\n";
 			}
 
-			if (empty($rConfig['http'])) {
-			} else {
-				echo 'RTMP Port: ' . $rConfig['rtmp'] . "\n";
-			}
+                        if (empty($rConfig['rtmp'])) {
+                        } else {
+                                echo 'RTMP Port: ' . $rConfig['rtmp'] . "\n";
+                        }
 
 			shell_exec('sudo ' . MAIN_HOME . 'service reload 2>/dev/null');
 			echo "\n";


### PR DESCRIPTION
## Summary
- ensure the RTMP port summary only checks for the presence of the RTMP configuration before printing

## Testing
- php -l src/tools

------
https://chatgpt.com/codex/tasks/task_e_68cdc1e56234832f801292590becbe31