### PR TITLE
Fix PHP lint errors in igbinary documentation stub and M3U parser

### DIFF
--- a/src/bin/php/lib/php/doc/igbinary/igbinary.php
+++ b/src/bin/php/lib/php/doc/igbinary/igbinary.php
@@ -53,7 +53,12 @@
  * @return string Returns a string containing a binary representation of value that can be stored anywhere.
  * @link http://www.php.net/serialize PHP's default serialize
  */
-function igbinary_serialize($value);
+if (!function_exists('igbinary_serialize')) {
+    function igbinary_serialize($value)
+    {
+        return '';
+    }
+}
 
 /** Creates a PHP value from a stored representation.
  * igbinary_unserialize() takes a single serialized variable and converts it back into a PHP value.
@@ -70,4 +75,9 @@ function igbinary_serialize($value);
  * @link http://www.php.net/manual/en/function.unserialize.php PHP's default unserialize
  * @link https://secure.php.net/serializable Serializable interface
  */
-function igbinary_unserialize($str);
+if (!function_exists('igbinary_unserialize')) {
+    function igbinary_unserialize($str)
+    {
+        return null;
+    }
+}

--- a/src/includes/libs/m3u_v2.php
+++ b/src/includes/libs/m3u_v2.php
@@ -692,7 +692,7 @@ class DumperFacade
 	}
 }
 
-interface StreamInterface implements Iterator
+interface StreamInterface extends Iterator
 {
 	public function add($line);
 }


### PR DESCRIPTION
## Summary
- wrap igbinary serialize/unserialize documentation stubs in guard implementations so they parse correctly
- fix the M3U parser stream interface declaration to extend Iterator instead of implementing it

## Testing
- php -l src/bin/php/lib/php/doc/igbinary/igbinary.php
- php -l src/includes/libs/m3u_v2.php

------
https://chatgpt.com/codex/tasks/task_e_68e2e56a294c832f83433ce80b17e9f9